### PR TITLE
WAZO-680 provd API version in URL

### DIFF
--- a/bin/xivo-dxtora
+++ b/bin/xivo-dxtora
@@ -44,7 +44,6 @@ DEFAULT_CONFIG = {
     'prov_server': {
         'host': 'localhost',
         'port': 8666,
-        'prefix': '/provd',
         'verify_certificate': CERT_FILE,
     },
     'auth': {


### PR DESCRIPTION
reason: the API now uses a version number instead.