### PR TITLE
token_renewer: use new callback signature

### DIFF
--- a/bin/xivo-dxtora
+++ b/bin/xivo-dxtora
@@ -350,7 +350,9 @@ def main():
     auth_client = AuthClient(**config['auth'])
     provd_client = ProvdClient(**config['prov_server'])
     token_renewer = TokenRenewer(auth_client)
-    token_renewer.subscribe_to_token_change(provd_client.set_token)
+    token_renewer.subscribe_to_token_change(
+        lambda token: provd_client.set_token(token['token'])
+    )
     sink = ProvServerDHCPInfoSink(provd_client)
 
     with token_renewer:


### PR DESCRIPTION
token_renewer now passes the whole token object to callbacks